### PR TITLE
Change rock opt-in status

### DIFF
--- a/app/graphql/mutations/users/update_user_optin_status.rb
+++ b/app/graphql/mutations/users/update_user_optin_status.rb
@@ -1,0 +1,15 @@
+module Mutations
+  module Users
+    class UpdateUserOptinStatus < ::Mutations::BaseMutation
+      argument :id, ID, required: true
+
+      type Types::UserType
+
+      def resolve(attributes)
+        user = User.where(id: attributes[:id]).first
+        !user.rock_opt_in ? user.update(rock_opt_in: true) : user.update(rock_opt_in: false)
+        user
+      end
+    end
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -8,6 +8,7 @@ module Types
     field :cancel_mentee_pairing, mutation: Mutations::Pairings::CancelMenteePairing
 
     field :update_user, mutation: Mutations::Users::UpdateUser
+    field :update_user_optin_status, mutation: Mutations::Users::UpdateUserOptinStatus
     field :update_pairing, mutation: Mutations::Pairings::UpdatePairing
     field :delete_pairings, mutation: Mutations::Pairings::DeleteUserPairings
     field :delete_user, mutation: Mutations::Users::DeleteUser

--- a/spec/graphql/mutations/users/update_user_optin_status_spec.rb
+++ b/spec/graphql/mutations/users/update_user_optin_status_spec.rb
@@ -19,6 +19,13 @@ RSpec.describe UpdateUserOptinStatus, type: :request do
       data = json['data']
 
       expect(data['user']['rockOptIn']).to eq(true)
+
+      post '/graphql', params: { query: query }
+
+      json = JSON.parse(response.body)
+      data = json['data']
+
+      expect(data['user']['rockOptIn']).to eq(false)
     end
 
     def get_query

--- a/spec/graphql/mutations/users/update_user_optin_status_spec.rb
+++ b/spec/graphql/mutations/users/update_user_optin_status_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+module Mutations
+  module Users
+RSpec.describe UpdateUserOptinStatus, type: :request do
+  describe '.resolve' do
+    it "updates a user's opt-in status" do
+      @rachel = create(:user, id: 1, name: "Rachel Lew", mod: "4")
+
+      result = PairedBeSchema.execute(get_query).as_json
+      expect(result["data"]["getUser"]["name"]).to eq("Rachel Lew")
+      expect(result["data"]["getUser"]["module"]).to eq("4")
+      expect(result["data"]["getUser"]["program"]).to eq("BE")
+      expect(result["data"]["getUser"]["rockOptIn"]).to eq(false)
+
+      post '/graphql', params: { query: query }
+
+      json = JSON.parse(response.body)
+      data = json['data']
+
+      expect(data['user']['rockOptIn']).to eq(true)
+    end
+
+    def get_query
+      <<~GQL
+      {
+        getUser(id: "1") {
+          name
+          program
+          module
+          id
+          image
+          rockOptIn
+        }
+      }
+      GQL
+    end
+
+    def query
+      <<~GQL
+      mutation {
+        user: updateUserOptinStatus(input: {id: "#{@rachel.id}"}) {
+          rockOptIn
+        }
+      }
+      GQL
+    end
+  end
+    end
+  end
+end


### PR DESCRIPTION
### Sidebar Checklist

- [x] Request reviewers
- [x] Assign yourself and other contributors
- [x] Link to project

### Issues Resolved
Resolves #5 

### Problem Addressed
We need a way to change a user's default rock opt-in status of false to true as well as a way to change it from true back to false.

### Solution Implemented
I created a new mutation to pass in an argument of the user's id, find the user associated with that id, change the rock opt-in status from false to true or true back to false, and then return the user.

### Other Notes
For the test, I reused a part of the test to get a single user to show that when I get a user, their opt-in status starts out as false, but after I make a query to our endpoint, the rock opt-in status changes to true.