### PR TITLE
Updates filter query for find available rocks 

### DIFF
--- a/app/graphql/filters/available_rocks.rb
+++ b/app/graphql/filters/available_rocks.rb
@@ -29,9 +29,9 @@ class Filters::AvailableRocks
       scope = scope.where('mod = ?', value[:module]) if value[:module]
       scope = scope.where(rock_opt_in: true)
       users = scope.left_outer_joins(:pebble_roles).where(rock_and_pebbles: { rock_id: nil } )
-      rock_and_pebbles = scope.left_outer_joins(:pebble_roles).where(rock_and_pebbles: {active: true}).group(:id).having('count(pebble_id) < 2')
+      rocks_true = scope.left_outer_joins(:pebble_roles).where(rock_and_pebbles: {active: true}).group(:id).having('count(pebble_id) < 2')
 
-      scope = users + rock_and_pebbles
+      scope = users + rocks_true
       branches << scope
 
       value[:OR].reduce(branches) { |s, v| normalize_filters(v, s) } if value[:OR].present?

--- a/spec/graphql/filters/find_available_rocks_spec.rb
+++ b/spec/graphql/filters/find_available_rocks_spec.rb
@@ -6,26 +6,32 @@ RSpec.describe Types::QueryType do
 
         #user_1 and user_2 should be returned in the query
         user = create(:user, mod: 2, program: "BE",  rock_opt_in: true)
-        user_1 = create(:user, mod: 2, program: "BE", rock_opt_in: true)
+        user_1 = create(:user, id: 34, mod: 2, program: "BE", rock_opt_in: true)
         user_2 = create(:user, mod: 2, program: "BE", rock_opt_in: true)
-        user_3 = create(:user, mod: 2, program: "BE")
+        user_3 = create(:user, id: 35, mod: 2, program: "BE", rock_opt_in: true)
+        user_8 = create(:user, mod: 2, program: "BE")
 
         user_4 = create(:user, mod: 3, program: "BE", rock_opt_in: true)
         user_5 = create(:user, mod: 4, program: "FE", rock_opt_in: true)
         user_6 = create(:user, mod: 3, program: "FE", rock_opt_in: true)
         user_7 = create(:user, mod: 4, program: "FE")
 
+        # creates a rock with two or more active pebbles
         RockAndPebble.create(rock_id: user.id, pebble_id: user_5.id, active: true)
         RockAndPebble.create(rock_id: user.id, pebble_id: user_6.id, active: true)
-
+        # creates a rock with one active and one inactive pebble.
         RockAndPebble.create(rock_id: user_1.id, pebble_id: user_7.id, active: false)
         RockAndPebble.create(rock_id: user_1.id, pebble_id: user_5.id, active: true)
+        # creates rock with two inactive pebbles
+        RockAndPebble.create(rock_id: user_3.id, pebble_id: user_5.id, active: false)
+        RockAndPebble.create(rock_id: user_3.id, pebble_id: user_6.id, active: false)
 
       result = PairedBeSchema.execute(query).as_json
 
-      expect(result["data"]["findAvailableRocks"].count).to eq(2)
+      expect(result["data"]["findAvailableRocks"].count).to eq(3)
       expect(result["data"]["findAvailableRocks"][0]["name"]).to eq(user_1.name)
       expect(result["data"]["findAvailableRocks"][1]["name"]).to eq(user_2.name)
+      expect(result["data"]["findAvailableRocks"][2]["name"]).to eq(user_3.name)
     end
   end
 

--- a/spec/graphql/filters/find_available_rocks_spec.rb
+++ b/spec/graphql/filters/find_available_rocks_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe Types::QueryType do
   describe 'display rocks' do
     it 'can query all available rocks' do
 
-        #user_1 and user_2 should be returned in the query
+        #user_1, user_2, and user_3 should be returned in the query
         user = create(:user, mod: 2, program: "BE",  rock_opt_in: true)
-        user_1 = create(:user, id: 34, mod: 2, program: "BE", rock_opt_in: true)
+        user_1 = create(:user, mod: 2, program: "BE", rock_opt_in: true)
         user_2 = create(:user, mod: 2, program: "BE", rock_opt_in: true)
-        user_3 = create(:user, id: 35, mod: 2, program: "BE", rock_opt_in: true)
+        user_3 = create(:user, mod: 2, program: "BE", rock_opt_in: true)
         user_8 = create(:user, mod: 2, program: "BE")
 
         user_4 = create(:user, mod: 3, program: "BE", rock_opt_in: true)
@@ -16,15 +16,17 @@ RSpec.describe Types::QueryType do
         user_6 = create(:user, mod: 3, program: "FE", rock_opt_in: true)
         user_7 = create(:user, mod: 4, program: "FE")
 
-        # creates a rock with two or more active pebbles
+        # creates a rock with two or more active pebbles - should not be returned
         RockAndPebble.create(rock_id: user.id, pebble_id: user_5.id, active: true)
         RockAndPebble.create(rock_id: user.id, pebble_id: user_6.id, active: true)
-        # creates a rock with one active and one inactive pebble.
+        RockAndPebble.create(rock_id: user.id, pebble_id: user_7.id, active: false)
+        # creates a rock with one active and one inactive pebble - should be returned
         RockAndPebble.create(rock_id: user_1.id, pebble_id: user_7.id, active: false)
         RockAndPebble.create(rock_id: user_1.id, pebble_id: user_5.id, active: true)
-        # creates rock with two inactive pebbles
+        # creates rock with two inactive pebbles - should be returned
         RockAndPebble.create(rock_id: user_3.id, pebble_id: user_5.id, active: false)
         RockAndPebble.create(rock_id: user_3.id, pebble_id: user_6.id, active: false)
+        RockAndPebble.create(rock_id: user_3.id, pebble_id: user_7.id, active: false)
 
       result = PairedBeSchema.execute(query).as_json
 


### PR DESCRIPTION
### Sidebar Checklist

- [x] Request reviewers
- [x] Assign yourself and other contributors
- [x] Link to project

### Issues Resolved
Resolves #
Fixes a bug. An issue was not made.
### Problem Addressed
The query was not filtering for users that were on the rock_and_pebble table but all pebbles were inactive. 
### Solution Implemented
Cleaned up original query to be one query vs. two separate queries. Refactored so that the counting for active pebbles is part of a sub query which also solved the problem of finding rocks that had inactive pebbles. 
### Other Notes
Daniel Frampton has some solid SQL skills!