### PR TITLE
Rb status to active

### DIFF
--- a/app/graphql/mutations/rock_and_pebbles/activate_rock_pebble_relationship.rb
+++ b/app/graphql/mutations/rock_and_pebbles/activate_rock_pebble_relationship.rb
@@ -1,0 +1,23 @@
+module Mutations
+  module RockAndPebbles
+    class ActivateRockPebbleRelationship < ::Mutations::BaseMutation
+      argument :id, ID, required: true
+      type Types::RockAndPebbleType
+
+      def resolve(attributes)
+        rock_and_pebble = RockAndPebble.find(attributes[:id])
+        send_pebble_confirmation_email(rock_and_pebble)
+        rock_and_pebble.update(active: true)
+        rock_and_pebble
+      end
+
+      private
+
+      def send_pebble_confirmation_email(rock_and_pebble)
+        info = rock_and_pebble.rock_pebble_info
+        NotificationsWorker.rock_pebble_message(info, :rock_accepted_message)
+      end
+    end
+  end
+end
+

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -14,5 +14,6 @@ module Types
     field :delete_user, mutation: Mutations::Users::DeleteUser
 
     field :decline_rock_pebble_relationship, mutation: Mutations::RockAndPebbles::DeclineRockPebbleRelationship
+    field :activate_rock_pebble_relationship, mutation: Mutations::RockAndPebbles::ActivateRockPebbleRelationship
   end
 end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -15,5 +15,6 @@ module Types
 
     field :decline_rock_pebble_relationship, mutation: Mutations::RockAndPebbles::DeclineRockPebbleRelationship
     field :create_rock_pebble_relationship, mutation: Mutations::RockAndPebbles::CreateRockPebbleRelationship
+    field :activate_rock_pebble_relationship, mutation: Mutations::RockAndPebbles::ActivateRockPebbleRelationship
   end
 end

--- a/spec/graphql/mutations/rock_and_pebble/activate_rock_pebble_spec.rb
+++ b/spec/graphql/mutations/rock_and_pebble/activate_rock_pebble_spec.rb
@@ -6,30 +6,51 @@ RSpec.describe 'activate rock and pebble relationship', type: :request do
             @user_2 = create :user
             @user_1.pebbles << @user_2
             @relationship = RockAndPebble.first
-            @user_3 = create :user
-            @user_4 = create :user
-            @user_3.pebbles << @user_4
-            @other_relationship = RockAndPebble.last
     end
 
     describe '.resolve' do
-        it 'switches the active status of the relationship to true' do
-            expect(RockAndPebble.count).to eq(2)
+        it 'switches the active status of the relationship to true and send rock accepted email' do
+            expect(RockAndPebble.count).to eq(1)
+            expect(@relationship.active).to eq(false)
             post '/graphql', params: {query: query}
-            expect(@relationship.active).to eq(true)
-            expect(@other_relationship.active).to eq(false)
-        end
+            result = JSON.parse(response.body)
+            expect(result['data']['rock_and_pebble']['id']).to eq(@relationship.id.to_s)
+            expect(result['data']['rock_and_pebble']['active']).to eq(true)
+            expect(result['data']['rock_and_pebble']['rock']['id']).to eq(@user_1.id.to_s)
+            expect(result['data']['rock_and_pebble']['pebble']['id']).to eq(@user_2.id.to_s)
+            expect do
+            post '/graphql', params: {query: query}
+            end.
+            to change { ActionMailer::Base.deliveries.count }.by(1)
+          end
     end
         def query
             <<~GQL
                 mutation {
-                    rock_and_pebble: activateRockAndPebble(
+                    rock_and_pebble: activateRockPebbleRelationship(
                     input: {
                     id: #{@relationship.id}
                     }
                     ){
-                    rock{id}
-                    pebble{id}
+                      id
+                      rock {
+                        id
+                        name
+                        pronouns
+                        program
+                        module
+                        slack
+                      }
+                      pebble {
+                        id
+                        name
+                        pronouns
+                        program
+                        module
+                        slack
+                      }
+                      active
+
                 }
                 }
             GQL

--- a/spec/graphql/mutations/rock_and_pebble/activate_rock_pebble_spec.rb
+++ b/spec/graphql/mutations/rock_and_pebble/activate_rock_pebble_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe 'activate rock and pebble relationship', type: :request do
+    before :each do
+            @user_1 = create :user
+            @user_2 = create :user
+            @user_1.pebbles << @user_2
+            @relationship = RockAndPebble.first
+            @user_3 = create :user
+            @user_4 = create :user
+            @user_3.pebbles << @user_4
+            @other_relationship = RockAndPebble.last
+    end
+
+    describe '.resolve' do
+        it 'switches the active status of the relationship to true' do
+            expect(RockAndPebble.count).to eq(2)
+            post '/graphql', params: {query: query}
+            expect(@relationship.active).to eq(true)
+            expect(@other_relationship.active).to eq(false)
+        end
+    end
+        def query
+            <<~GQL
+                mutation {
+                    rock_and_pebble: activateRockAndPebble(
+                    input: {
+                    id: #{@relationship.id}
+                    }
+                    ){
+                    rock{id}
+                    pebble{id}
+                }
+                }
+            GQL
+    end
+end


### PR DESCRIPTION
### Sidebar Checklist

- [X] Request reviewers
- [X] Assign yourself and other contributors
- [X] Link to project

### Issues Resolved
Resolves #7 

### Problem Addressed
Switches active column on rock and pebble relationship to true and returns the updated rock and pebble relationship. It also needs to notify the pebble that the rock accepted via email. 

### Solution Implemented
Created a new mutation that takes the rock and pebble id as an input. This resolver finds the record and then updates the active column on it. This also calls a method to send out the rock accepted email via the NotificationsWorker.

### Other Notes
One spec file has been added - it tests that active changes from false to true after the request goes through. It also tests that an email is sent by checking that the ActionMailer deliveries count goes up by 1. 
