### PR TITLE
Update seed data with rock-and-pebble and test user

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,19 +11,19 @@ User.destroy_all
 Interest.destroy_all
 Skill.destroy_all
 Pairing.destroy_all
-
-10.times do
-  create(:user)
-end
+RockAndPebble.destroy_all
 
 30.times do
-  count = User.count - 1
-  user = User.offset(rand(0..count)).limit(1).first
-  create(:skill, user: user )
+  new_user = create(:user)
+  rand(1..3).times do
+    create(:skill, user: new_user )
+  end
+  rand(1..3).times do
+    create(:pairing, pairer: new_user, pairee: nil)
+  end
 end
 
-5.times do
-
+15.times do
   count = User.count - 1
   user_1 = User.offset(rand(0..count)).limit(1).first
   user_2 = User.offset(rand(0..count)).limit(1).first
@@ -31,3 +31,31 @@ end
   create(:pairing, pairer_id: user_1.id, pairee_id: user_2.id)
   create(:pairing, pairer_id: user_2.id, pairee_id: user_1.id)
  end
+
+15.times do
+  count = User.count - 1
+  user_1 = User.offset(rand(0..count)).limit(1).first
+  user_2 = User.offset(rand(0..count)).limit(1).first
+
+  create(:rock_and_pebble, rock: user_1, pebble: user_2)
+end
+
+# Test user integrated into seed data for faster manual integration testing.
+# There is a real Github account associated with this address with a real Firebase ID.
+# Firebase ID is associated with the staging area Firebase account, won't work in production repo.
+all_users = User.all # for sampling below
+test_user = create(:user, email: 'landslideappteam@gmail.com', firebase_id: 'STgm6VyJm9eGV2ZgARQ2j5lusWG3')
+create_list(:skill_from_dropdown, 2, user: test_user)
+create(:skill, user: test_user)
+# for View Schedule
+create_list(:pairing_with_notes, 3, pairer: test_user, pairee: all_users.sample) # Giving Help
+create_list(:pairing_with_notes, 3, pairer: all_users.sample, pairee: test_user) # Receiving Help
+create_list(:pairing, 10, pairer: test_user, pairee: nil) # Open to Pair
+# for testing stats pages
+create_list(:past_pairing, 5, pairee: all_users.sample, pairer: test_user)
+create_list(:past_pairing, 5, pairer: all_users.sample, pairee: test_user)
+# for testing rock and pebble
+create(:rock_and_pebble, rock: test_user, pebble: all_users.sample, active: false)
+create(:rock_and_pebble, rock: test_user, pebble: all_users.sample, active: true)
+# create(:rock_and_pebble, rock: all_users.sample, pebble: test_user, active: true)
+# create(:rock_and_pebble, rock: all_users.sample, pebble: test_user, active: false)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,7 +14,7 @@ Pairing.destroy_all
 RockAndPebble.destroy_all
 
 30.times do
-  new_user = create(:user)
+  new_user = create(:user_random_opt_in)
   rand(1..3).times do
     create(:skill, user: new_user )
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -43,19 +43,21 @@ end
 # Test user integrated into seed data for faster manual integration testing.
 # There is a real Github account associated with this address with a real Firebase ID.
 # Firebase ID is associated with the staging area Firebase account, won't work in production repo.
-all_users = User.all # for sampling below
 test_user = create(:user, email: 'landslideappteam@gmail.com', firebase_id: 'STgm6VyJm9eGV2ZgARQ2j5lusWG3')
 create_list(:skill_from_dropdown, 2, user: test_user)
 create(:skill, user: test_user)
+all_users = User.where.not(id: test_user.id) # for sampling below
 # for View Schedule
-create_list(:pairing_with_notes, 3, pairer: test_user, pairee: all_users.sample) # Giving Help
-create_list(:pairing_with_notes, 3, pairer: all_users.sample, pairee: test_user) # Receiving Help
+3.times { create(:pairing_with_notes, pairer: test_user, pairee: all_users.sample) } # Giving Help
+3.times { create(:pairing_with_notes, pairer: all_users.sample, pairee: test_user) } # Receiving Help
 create_list(:pairing, 10, pairer: test_user, pairee: nil) # Open to Pair
 # for testing stats pages
-create_list(:past_pairing, 5, pairee: all_users.sample, pairer: test_user)
-create_list(:past_pairing, 5, pairer: all_users.sample, pairee: test_user)
-# for testing rock and pebble
-create(:rock_and_pebble, rock: test_user, pebble: all_users.sample, active: false)
-create(:rock_and_pebble, rock: test_user, pebble: all_users.sample, active: true)
-# create(:rock_and_pebble, rock: all_users.sample, pebble: test_user, active: true)
-# create(:rock_and_pebble, rock: all_users.sample, pebble: test_user, active: false)
+5.times { create(:past_pairing, pairee: all_users.sample, pairer: test_user) }
+5.times { create(:past_pairing, pairer: all_users.sample, pairee: test_user) }
+# for testing user's pebbles
+create(:rock_and_pebble, rock: test_user, pebble: all_users.sample, active: false, pending: false)
+create(:rock_and_pebble, rock: test_user, pebble: all_users.sample, active: false, pending: true)
+create(:rock_and_pebble, rock: test_user, pebble: all_users.sample, active: true, pending: false)
+# for testing user's rocks
+create(:rock_and_pebble, rock: all_users.sample, pebble: test_user, active: true, pending: false)
+create(:rock_and_pebble, rock: all_users.sample, pebble: test_user, active: false, pending: false)

--- a/spec/factories/pairings.rb
+++ b/spec/factories/pairings.rb
@@ -1,8 +1,16 @@
 FactoryBot.define do
   factory :pairing do
-    pairer {create :user}
-    pairee {create :user}
-    time { 'lunch' }
-    date { 'Wed Apr 03 2020'}
+    pairer { create :user }
+    pairee { create :user }
+    time { ['morning', 'lunch', 'afternoon'].sample }
+    date { (DateTime.now + rand(20)).strftime('%a %b %d %Y') }
+
+    factory :past_pairing do
+      date { (DateTime.now - rand(50)).strftime('%a %b %d %Y') }
+    end
+
+    factory :pairing_with_notes do
+      notes { Faker::Hacker.say_something_smart }
+    end
   end
 end

--- a/spec/factories/rock_and_pebble.rb
+++ b/spec/factories/rock_and_pebble.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     rock { create :user }
     pebble { create :user }
     active { [true, false].sample }
+    pending { true }
   end
 end

--- a/spec/factories/rock_and_pebble.rb
+++ b/spec/factories/rock_and_pebble.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :rock_and_pebble do
     rock { create :user }
     pebble { create :user }
-    active { false }
+    active { [true, false].sample }
   end
 end

--- a/spec/factories/skills.rb
+++ b/spec/factories/skills.rb
@@ -1,7 +1,30 @@
 FactoryBot.define do
   factory :skill do
-    name {Faker::FunnyName.name}
+    name { Faker::Superhero.power }
 
     association :user, factory: :user
+
+    factory :skill_from_dropdown do
+      name {
+        [
+          'grid',
+          'flexbox',
+          'mythical creatures',
+          'react',
+          'jsFun',
+          'rspec',
+          'rails',
+          'ruby',
+          'jest/enzyme',
+          'docker',
+          'lightning talks',
+          'javascript',
+          'css',
+          'active record',
+          'SQL',
+          'sinatra'
+        ].sample
+      }
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -9,6 +9,9 @@ FactoryBot.define do
     image { "https://robohash.org/#{name.downcase.delete(' ')}.png?size=200x200" }
     phone_number { '5555550100' }
     firebase_id { Faker::Alphanumeric.alphanumeric(number: 28 ) }
-    rock_opt_in { [true, false].sample }
+
+    factory :user_random_opt_in do
+      rock_opt_in { [true, false].sample }
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,13 +1,14 @@
 FactoryBot.define do
   factory :user do
-    name {Faker::FunnyName.name}
-    mod { Faker::Number.within(range: 1..5)}
-    program { "BE" }
-    pronouns { "She/her" }
-    slack  {Faker::FunnyName.name}
+    name {Faker::FunnyName.name }
+    mod { Faker::Number.within(range: 1..5) }
+    program { ['BE', 'FE'].sample }
+    pronouns { ['She/her/hers', 'He/him/his', 'They/them/their'].sample }
+    slack { '@' + name.downcase.delete(' ') }
     email { Faker::Internet.email }
-    image { Faker::LoremFlickr.image }
-    phone_number { "5555550100" }
-    firebase_id { Faker::Alphanumeric.alphanumeric(number: 28 )}
+    image { "https://robohash.org/#{name.downcase.delete(' ')}.png?size=200x200" }
+    phone_number { '5555550100' }
+    firebase_id { Faker::Alphanumeric.alphanumeric(number: 28 ) }
+    rock_opt_in { [true, false].sample }
   end
 end

--- a/spec/graphql/mutations/users/update_user_optin_status_spec.rb
+++ b/spec/graphql/mutations/users/update_user_optin_status_spec.rb
@@ -5,7 +5,7 @@ module Mutations
 RSpec.describe UpdateUserOptinStatus, type: :request do
   describe '.resolve' do
     it "updates a user's opt-in status" do
-      @rachel = create(:user, id: 1, name: "Rachel Lew", mod: "4")
+      @rachel = create(:user, name: "Rachel Lew", program: 'BE', mod: "4")
 
       result = PairedBeSchema.execute(get_query).as_json
       expect(result["data"]["getUser"]["name"]).to eq("Rachel Lew")
@@ -31,7 +31,7 @@ RSpec.describe UpdateUserOptinStatus, type: :request do
     def get_query
       <<~GQL
       {
-        getUser(id: "1") {
+        getUser(id: "#{@rachel.id}") {
           name
           program
           module

--- a/spec/graphql/queries/users/get_single_user_spec.rb
+++ b/spec/graphql/queries/users/get_single_user_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Types::QueryType do
   describe 'display users' do
     it 'can query a single user' do
-      create(:user, id: 1, name: "Cate Blanchett", mod: "3")
+      create(:user, id: 1, name: "Cate Blanchett", mod: "3", program: 'BE')
       create_list(:user, 4)
 
       result = PairedBeSchema.execute(query).as_json


### PR DESCRIPTION
### Sidebar Checklist

- [x] Request reviewers
- [x] Assign yourself and other contributors
- [x] Link to project

### Issues Resolved
Resolves nothing, needed a quicker way to set up manual testing context

### Problem Addressed
Didn't have a test user that was integrated into the seed data; could only log in as myself, and then had to manually create connections between my user and the ones created by the seeds file.

### Solution Implemented
I created a Github account using the email address that belongs to our team, `landslideappteam@gmail.com`, authenticated it once so a Firebase ID would get generated, copied that Firebase ID, and then added the creation of a user with that Firebase ID to the seeds file. I'll pin the password for that Github account in the Slack channel. 

To use it, log out of your actual Github account and then log in using this test account to Paired. Because a lot of the pairing info is time-sensitive, this will be most helpful if you deploy the back-end locally and nuke your DB Mike Dao YOLO style, `rails db:{drop,create,migrate,seed}`, so that the available pairings show in the dropdown menus (which look 2 weeks out).

### Other Notes
This will need to get refactored slightly after Becky makes her PR to add a 'pending' field to the `rock_and_pebbles` table in the database.

### Obligatory GIF
![](https://media.giphy.com/media/26u42gg86HoJyjy8w/giphy-downsized.gif)
