### PR TITLE
Correct hash key reference from camel to snake

### DIFF
--- a/app/graphql/mutations/rock_and_pebbles/discontinue_rock_pebble_relationship.rb
+++ b/app/graphql/mutations/rock_and_pebbles/discontinue_rock_pebble_relationship.rb
@@ -21,7 +21,7 @@ module Mutations
         def send_pebble_email(rock_and_pebble, attributes)
           reason = attributes[:reason]
           info = rock_and_pebble.rock_pebble_info
-          if attributes[:userRelationship] == 'pebble'
+          if attributes[:user_relationship] == 'pebble'
             NotificationsWorker.rock_pebble_message(info, reason, :pebble_relationship_discontinued)
           else
             NotificationsWorker.rock_pebble_message(info, reason, :rock_relationship_discontinued)


### PR DESCRIPTION
Fixes problem when Rock discontinued relationship and got email saying Pebble had discontinued it; problem was that the if condition for sending the correct email was never triggering b/c hash value was referred to in camel case, but by this point GraphQL Ruby had converted it to snake.